### PR TITLE
Fixxed Compatiblity to PHP5.6

### DIFF
--- a/src/MarketplaceWebService/Client.php
+++ b/src/MarketplaceWebService/Client.php
@@ -88,10 +88,17 @@ class MarketplaceWebService_Client implements MarketplaceWebService_Interface
    * </ul>
    */
   public function __construct(
-  $awsAccessKeyId, $awsSecretAccessKey, $config, $applicationName, $applicationVersion, $attributes = null) {
-	iconv_set_encoding('output_encoding', 'UTF-8');
-    iconv_set_encoding('input_encoding', 'UTF-8');
-    iconv_set_encoding('internal_encoding', 'UTF-8');
+  $awsAccessKeyId, $awsSecretAccessKey, $config, $applicationName, $applicationVersion, $attributes = null)
+  {
+
+
+      if (version_compare(phpversion(), '5.6.0', '<')) {
+          iconv_set_encoding('output_encoding', 'UTF-8');
+          iconv_set_encoding('input_encoding', 'UTF-8');
+          iconv_set_encoding('internal_encoding', 'UTF-8');
+      }
+
+
 
     $this->awsAccessKeyId = $awsAccessKeyId;
     $this->awsSecretAccessKey = $awsSecretAccessKey;


### PR DESCRIPTION
Hello

I am using you Library for making my Amazon Repricing Tool. Many Thanks for contributing it to the Community.
Unfortunatly i ran into an issue:
PHP5.6 ist giving me an "iconv_set_encoding(): Use of iconv.output_encoding is deprecated  " deprecated Error. 

I created a patch for it,and want to submit it.