### PR TITLE
Fixed fatal error during response XML rebuilding

### DIFF
--- a/src/MarketplaceWebService/Model.php
+++ b/src/MarketplaceWebService/Model.php
@@ -91,7 +91,7 @@ abstract class MarketplaceWebService_Model
      * This fragment returns inner fields representation only
      * @return string XML fragment for this object
      */
-    protected function toXMLFragment() 
+    protected function _toXMLFragment()
     {
         $xml = "";
         foreach ($this->fields as $fieldName => $field) {
@@ -102,7 +102,7 @@ abstract class MarketplaceWebService_Model
                     if ($this->isComplexType($fieldType[0])) {
                         foreach ($fieldValue as $item) {
                             $xml .= "<$fieldName>";
-                            $xml .= $item->toXMLFragment();
+                            $xml .= $item->_toXMLFragment();
                             $xml .= "</$fieldName>";
                         }
                     } else {
@@ -115,7 +115,7 @@ abstract class MarketplaceWebService_Model
                 } else {
                     if ($this->isComplexType($fieldType)) {
                         $xml .= "<$fieldName>";
-                        $xml .= $fieldValue->toXMLFragment();
+                        $xml .= $fieldValue->_toXMLFragment();
                         $xml .= "</$fieldName>";
                     } else {
                         $xml .= "<$fieldName>";


### PR DESCRIPTION
When attempting to call `toXML` method on a response there was an error due missing `_toXMLFragment` method call. In fact method was named `toXMLFragment` (without underscore) in parent class.

I've renamed the method, because everywhere it was used with the underscore.